### PR TITLE
General PEP compliance, add docs, update ``_quadratic_form`` to ``spins_to_symbols``

### DIFF
--- a/dimod/generators/mimo.py
+++ b/dimod/generators/mimo.py
@@ -172,11 +172,34 @@ def _symbols_to_spins(symbols: np.array, modulation: str) -> np.array:
     return spins
 
 def _yF_to_hJ(y, F, modulation):
-    offset, h, J = _quadratic_form(y, F) # Quadratic form re-expression
-    # Complex to real symbols (if necessary): 
+    """Convert :math:`O(v) = ||y - F v||^2` to modulated quadratic form.
+    
+    Constructs coefficients for the form 
+    :math:`O(v) = v^{\dagger} J v - 2 \Re(h^{\dagger} v) + \\text{offset}`. 
+
+    Args:
+        y: Received symbols as a NumPy column vector of complex or real values.
+
+        F: Wireless channel as an :math:`i \\times j` NumPy matrix of complex 
+            values, where :math:`i` rows correspond to :math:`y_i` receivers 
+            and :math:`j` columns correspond to :math:`v_i` transmitted symbols.
+
+        modulation: Modulation. Supported values are non-quadrature modulation 
+            BPSK and quadrature modulations 'QPSK', '16QAM', '64QAM', and '256QAM'.
+    
+    Returns:
+        Three tuple of amplitude-modulated linear biases :math:`h`, as a NumPy
+        vector, amplitude-modulated quadratic interactions, :math:`J`, as a  
+        matrix, and offset as a real scalar.
+    """
+    offset, h, J = _quadratic_form(y, F) # Conversion to quadratic form 
+
+    # Separate real and imaginary parts of quadratic form: 
     h, J = _real_quadratic_form(h, J, modulation) 
-    # Real symbol to linear spin encoding:
+
+    # Amplitude-modulate the biases in the quadratic form:
     h, J = _amplitude_modulated_quadratic_form(h, J, modulation) 
+
     return h, J, offset
 
 def linear_filter(F, method='zero_forcing', SNRoverNt=float('Inf'), PoverNt=1):

--- a/dimod/generators/mimo.py
+++ b/dimod/generators/mimo.py
@@ -42,7 +42,6 @@ def _quadratic_form(y, F):
         Three tuple of offset, as a real scalar, linear biases :math:`h`, as a dense
         real vector, and quadratic interactions, :math:`J`, as a dense real symmetric 
         matrix.
-    
     """
     if len(y.shape) != 2 or y.shape[1] != 1:
         raise ValueError(f"y should have shape (n, 1) for some n; given: {y.shape}")
@@ -92,17 +91,35 @@ def _real_quadratic_form(h, J, modulation=None):
         return h.real, J.real
 
 def _amplitude_modulated_quadratic_form(h, J, modulation):
+    """Amplitude-modulate the quadratic form.
+    
+    Updates bias amplitudes for quadrature amplitude modulation.
+
+    Args:
+        h: Linear biases as a NumPy vector. 
+        
+        J: Quadratic interactions as a matrix.
+
+        modulation: Modulation. Supported values are non-quadrature modulations 
+        'BPSK', 'QPSK' and '16QAM' and quadrature modulations '64QAM' and '256QAM'.
+
+    Returns:
+        Two-tuple of amplitude-modulated linear biases, :math:`h`, as a NumPy 
+        vector  and amplitude-modulated quadratic interactions, :math:`J`, as 
+        a matrix.
+    """
     if modulation == 'BPSK' or modulation == 'QPSK':
         #Easy case, just extract diagonal
         return h, J
     else:
-        #Quadrature + amplitude modulation
+        # Quadrature + amplitude modulation
         if modulation == '16QAM':
             num_amps = 2
         elif modulation == '64QAM':
             num_amps = 3
         else:
             raise ValueError('unknown modulation')
+        
         amps = 2 ** np.arange(num_amps)
         hA = np.kron(amps[:, np.newaxis], h)
         JA = np.kron(np.kron(amps[:, np.newaxis], amps[np.newaxis, :]), J)

--- a/dimod/generators/mimo.py
+++ b/dimod/generators/mimo.py
@@ -59,11 +59,30 @@ def _quadratic_form(y, F):
     return offset, h, J
 
 def _real_quadratic_form(h, J, modulation=None):
-    """Unwraps objective function on complex variables onto objective
-    function of concatenated real variables: the real and imaginary
-    parts.
+    """Separate real and imaginary parts of quadratic form.
+    
+    Unwraps objective function on complex variables as an objective function of 
+    concatenated real variables, first the real and then the imaginary part.
+
+    Args:
+        h: Linear biases as a dense real NumPy vector. 
+        
+        J: Quadratic interactions as a dense real symmetric matrix.
+
+        modulation: Modulation. Supported values are 'BPSK', 'QPSK', '16QAM', 
+            '64QAM', and '256QAM'.
+
+    Returns:
+        Two-tuple of linear biases, :math:`h`, as a NumPy real vector with any 
+        imaginary part following the real part, and quadratic interactions, 
+        :math:`J`, as a real matrix with any imaginary part moved to above and 
+        below the diagonal.
     """
-    if modulation != 'BPSK' and (h.dtype == np.complex128 or J.dtype == np.complex128):
+    # JP: I added this but awaiting answer from Jack on BPSK ignoring F-induced complex parts 
+    # if modulation == 'BPSK' and (any(np.iscomplex(h)) or any(np.iscomplex(J))): 
+    #     raise ValueError('BPSK biases cannot have complex values')
+
+    if modulation != 'BPSK' and (any(np.iscomplex(h)) or any(np.iscomplex(J))):
         hR = np.concatenate((h.real, h.imag), axis=0)
         JR = np.concatenate((np.concatenate((J.real, J.imag), axis=0), 
                              np.concatenate((J.imag.T, J.real), axis=0)), 

--- a/dimod/generators/mimo.py
+++ b/dimod/generators/mimo.py
@@ -217,16 +217,17 @@ def linear_filter(F, method='zero_forcing', SNRoverNt=float('Inf'), PoverNt=1):
     """Construct a linear filter for estimating transmitted signals. 
     
     # Jack: you'll need to go over the following carefully
-    Following the conventions of MacKay\ [#Mackay]_, a filter is constructed for:
+    Following the conventions of MacKay\ [#Mackay]_, a filter is constructed for independent and identically 
+    distributed Gaussian noise at power spectral density `N_0`:
 
     :math:`N_0 I[N_r] = E[n n^{\dagger}]`
 
-    For independent and identically distributed (i.i.d) elements 
-    :math:`(1, 2, 10, 42)N_t` for BPSK, QPSK, 16QAM, 64QAM, 
+    For independent and identically distributed (i.i.d), zero mean, transmitted symbols 
 
-    :math:`P/N_t I[N_t] = E[v v^{\dagger}] \qquad \Rightarrow \qquad P = <P_c> N_t`, 
+    :math:`P_c I[N_t] = E[v v^{\dagger}]`
 
-    where :math:`<P_{c}>` is the constellation's mean power. 
+    where :math:`P_{c}` is the constellation's mean power equal to  :math:`(1, 2, 10, 42)N_t` 
+    for BPSK, QPSK, 16QAM, 64QAM respectively.
 
     For an i.i.d channel,
     
@@ -234,13 +235,14 @@ def linear_filter(F, method='zero_forcing', SNRoverNt=float('Inf'), PoverNt=1):
      
     Symbols are assumed to be normalized:
 
-    :math:`\\frac{SNR}{N_t} = \\frac{P}{Nt}/N_0` 
+    :math:`\\frac{SNR}{N_t} = \\frac{P_c}{N_0}` 
     
-    :math:`SNRb = \\frac{SNR}{N_t bps}`
+    :math:`SNR_b = \\frac{SNR}{N_t B_c}`
 
-    where :math:`bps` is bit per symbol.
+    where :math:`B_c` is bit per symbol  equal to  :math:`(1, 2, 4, 8)` 
+    for BPSK, QPSK, 16QAM, 64QAM respectively 
 
-    Typical use case: set :math:`\\frac{SNR}{N_t} = SNRb`.
+    Typical use case: set :math:`\\frac{SNR}{N_t} = SNR_b`.
 
     .. [#Mackay] Matthew R. McKay, Iain B. Collings, Antonia M. Tulino. 
         "Achievable sum rate of MIMO MMSE receivers: A general analytic framework" 

--- a/dimod/generators/mimo.py
+++ b/dimod/generators/mimo.py
@@ -224,7 +224,7 @@ def linear_filter(F, method='zero_forcing', SNRoverNt=float('Inf'), PoverNt=1):
     For independent and identically distributed (i.i.d) elements 
     :math:`(1, 2, 10, 42)N_t` for BPSK, QPSK, 16QAM, 64QAM, 
 
-    :math:`P/N_t I[N_t] = E[v v^{\dagger}] \qquad \Rightarrow \qquad P = <P_c>*N_t`, 
+    :math:`P/N_t I[N_t] = E[v v^{\dagger}] \qquad \Rightarrow \qquad P = <P_c> N_t`, 
 
     where :math:`<P_{c}>` is the constellation's mean power. 
 
@@ -234,7 +234,7 @@ def linear_filter(F, method='zero_forcing', SNRoverNt=float('Inf'), PoverNt=1):
      
     Symbols are assumed to be normalized:
 
-    :math:`\\frac{SNR}{N_t} = \\frac{P}{Nt}/N0` 
+    :math:`\\frac{SNR}{N_t} = \\frac{P}{Nt}/N_0` 
     
     :math:`SNRb = \\frac{SNR}{N_t bps}`
 

--- a/dimod/generators/mimo.py
+++ b/dimod/generators/mimo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2022 D-Wave Systems Inc.
+# Copyright 2023 D-Wave Systems Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -18,14 +18,15 @@
 #Author: Jack Raymond
 #Date: December 18th 2020
 
-import numpy as np
-import dimod 
 from itertools import product
-from typing import Callable, Iterable, Optional, Sequence, Tuple, Union
 import networkx as nx
+import numpy as np
+from typing import Callable, Iterable, Optional, Sequence, Tuple, Union
+
+import dimod 
 
 def _quadratic_form(y, F):
-    '''Convert O(v) = ||y - F v||^2 to a sparse quadratic form, where
+    """Convert O(v) = ||y - F v||^2 to a sparse quadratic form, where
     y, F are assumed to be complex or real valued.
 
     Constructs coefficients for the form O(v) = v^dag J v - 2 Re [h^dag vD] + k
@@ -39,7 +40,7 @@ def _quadratic_form(y, F):
         h: dense real vector
         J: dense real symmetric matrix
     
-    '''
+    """
     if len(y.shape) != 2 or y.shape[1] != 1:
         raise ValueError('y should have shape [n, 1] for some n')
     if len(F.shape) != 2 or F.shape[0] != y.shape[0]:
@@ -47,21 +48,21 @@ def _quadratic_form(y, F):
                          'and n should equal y.shape[1]')
 
     offset = np.matmul(y.imag.T, y.imag) + np.matmul(y.real.T, y.real)
-    h = - 2*np.matmul(F.T.conj(), y) ## Be careful with interpretaion!
+    h = - 2*np.matmul(F.T.conj(), y) ## Be careful with interpretation!
     J = np.matmul(F.T.conj(), F) 
 
     return offset, h, J
 
 def _real_quadratic_form(h, J, modulation=None):
-    '''Unwraps objective function on complex variables onto objective
+    """Unwraps objective function on complex variables onto objective
     function of concatenated real variables: the real and imaginary
     parts.
-    '''
+    """
     if modulation != 'BPSK' and (h.dtype == np.complex128 or J.dtype == np.complex128):
         hR = np.concatenate((h.real, h.imag), axis=0)
         JR = np.concatenate((np.concatenate((J.real, J.imag), axis=0), 
-                            np.concatenate((J.imag.T, J.real), axis=0)), 
-                           axis=1)
+                             np.concatenate((J.imag.T, J.real), axis=0)), 
+                             axis=1)
         return hR, JR
     else:
         return h.real, J.real
@@ -78,7 +79,7 @@ def _amplitude_modulated_quadratic_form(h, J, modulation):
             num_amps = 3
         else:
             raise ValueError('unknown modulation')
-        amps = 2**np.arange(num_amps)
+        amps = 2 ** np.arange(num_amps)
         hA = np.kron(amps[:, np.newaxis], h)
         JA = np.kron(np.kron(amps[:, np.newaxis], amps[np.newaxis, :]), J)
         return hA, JA 
@@ -125,8 +126,10 @@ def _symbols_to_spins(symbols: np.array, modulation: str) -> np.array:
 
 def _yF_to_hJ(y, F, modulation):
     offset, h, J = _quadratic_form(y, F) # Quadratic form re-expression
-    h, J = _real_quadratic_form(h, J, modulation) # Complex symbols to real symbols (if necessary)
-    h, J = _amplitude_modulated_quadratic_form(h, J, modulation) # Real symbol to linear spin encoding
+    # Complex to real symbols (if necessary): 
+    h, J = _real_quadratic_form(h, J, modulation) 
+    # Real symbol to linear spin encoding:
+    h, J = _amplitude_modulated_quadratic_form(h, J, modulation) 
     return h, J, offset
 
 def linear_filter(F, method='zero_forcing', SNRoverNt=float('Inf'), PoverNt=1):
@@ -134,10 +137,13 @@ def linear_filter(F, method='zero_forcing', SNRoverNt=float('Inf'), PoverNt=1):
     # https://www.youtube.com/watch?v=U3qjVgX2poM
    
     
-    We follow conventions laid out in MacKay et al. 'Achievable sum rate of MIMO MMSE receivers: A general analytic framework'
+    We follow conventions laid out in MacKay et al. 'Achievable sum rate of MIMO 
+    MMSE receivers: A general analytic framework'
     N0 Identity[N_r] = E[n n^dagger]
-    P/N_t Identify[N_t] = E[v v^dagger], i.e. P = constellation_mean_power*Nt for i.i.d elements (1,2,10,42)Nt for BPSK, QPSK, 16QAM, 64QAM.
-    N_r N_t = E_F[Tr[F Fdagger]], i.e. E[||F_{mu,i}||^2]=1 for i.i.d channel.  - normalization is assumed to be pushed into symbols.
+    P/N_t Identify[N_t] = E[v v^dagger], i.e. P = constellation_mean_power*Nt for 
+    i.i.d elements (1,2,10,42)Nt for BPSK, QPSK, 16QAM, 64QAM.
+    N_r N_t = E_F[Tr[F Fdagger]], i.e. E[||F_{mu,i}||^2]=1 for i.i.d channel.  
+    normalization is assumed to be pushed into symbols.
     SNRoverNt = PoverNt/N0 : Intensive quantity. 
     SNRb = SNR/(Nt*bits_per_symbol)
 
@@ -151,10 +157,13 @@ def linear_filter(F, method='zero_forcing', SNRoverNt=float('Inf'), PoverNt=1):
         Nr, Nt = F.shape
          # Matched Filter
         if method == 'matched_filter':
-            W = F.conj().T/ np.sqrt(PoverNt)
+            W = F.conj().T / np.sqrt(PoverNt)
             # F = root(Nt/P) Fcompconj
         elif method == 'MMSE':
-            W = np.matmul(F.conj().T, np.linalg.pinv(np.matmul(F,F.conj().T) + np.identity(Nr)/SNRoverNt))/np.sqrt(PoverNt)
+            W = np.matmul(
+                F.conj().T, 
+                np.linalg.pinv(np.matmul(F, F.conj().T) + np.identity(Nr)/SNRoverNt)
+                         ) / np.sqrt(PoverNt)
         else:
             raise ValueError('Unsupported linear method')
     return W
@@ -172,19 +181,20 @@ def filter_marginal_estimator(x: np.array, modulation: str):
         else:
             raise ValueError('Unknown modulation')
         #Real part (nearest):
-        x_R = 2*np.round((x.real-1)/2)+1
-        x_R = np.where(x_R<-max_abs,-max_abs,x_R)
-        x_R = np.where(x_R>max_abs,max_abs,x_R)
+        x_R = 2*np.round((x.real - 1)/2) + 1
+        x_R = np.where(x_R < -max_abs, -max_abs, x_R)
+        x_R = np.where(x_R > max_abs, max_abs, x_R)
         if modulation != 'BPSK':
-            x_I = 2*np.round((x.imag-1)/2)+1
-            x_I = np.where(x_I<-max_abs,-max_abs,x_I)
-            x_I = np.where(x_I>max_abs,max_abs,x_I)
+            x_I = 2*np.round((x.imag - 1)/2) + 1
+            x_I = np.where(x_I <- max_abs, -max_abs, x_I)
+            x_I = np.where(x_I > max_abs, max_abs, x_I)
             return x_R + 1j*x_I
         else:
             return x_R
         
-def spins_to_symbols(spins: np.array, modulation: str = None, num_transmitters: int = None) -> np.array:
-    "Converts spins to modulated symbols assuming a linear encoding"
+def spins_to_symbols(spins: np.array, modulation: str = None, 
+                     num_transmitters: int = None) -> np.array:
+    """Converts spins to modulated symbols assuming a linear encoding"""
     num_spins = len(spins)
     if num_transmitters is None:
         if modulation == 'BPSK':
@@ -214,7 +224,7 @@ def spins_to_symbols(spins: np.array, modulation: str = None, num_transmitters: 
         amps = 2**np.arange(0, num_amps)[:, np.newaxis]
         
         symbols = np.sum(amps*spinsR[:, :num_transmitters], axis=0) \
-                + 1j * np.sum(amps*spinsR[:, num_transmitters:], axis=0)
+                + 1j*np.sum(amps*spinsR[:, num_transmitters:], axis=0)
     return symbols
 
 def lattice_to_attenuation_matrix(lattice,transmitters_per_node=1,receivers_per_node=1,neighbor_root_attenuation=1):
@@ -312,7 +322,7 @@ def create_channel(num_receivers: int = 1, num_transmitters: int = 1,
 
     if F_distribution is None:
         F_distribution = ('normal', 'complex')    
-    elif type(F_distribution) is not tuple or len(F_distribution) !=2:
+    elif type(F_distribution) is not tuple or len(F_distribution) != 2:
         raise ValueError('F_distribution should be a tuple of strings or None')
     
     if F_distribution[0] == 'normal':
@@ -403,7 +413,7 @@ def _create_transmitted_symbols(num_transmitters,
         transmitted_symbols = random_state.choice(amps, size=(num_transmitters, 1))
     else: 
         transmitted_symbols = random_state.choice(amps, size=(num_transmitters, 1)) \
-            + 1j * random_state.choice(amps, size=(num_transmitters, 1))
+            + 1j*random_state.choice(amps, size=(num_transmitters, 1))
         
     return transmitted_symbols, random_state
 
@@ -502,6 +512,8 @@ def _create_signal(F, transmitted_symbols=None, channel_noise=None,
         y = channel_noise + np.matmul(F, transmitted_symbols)
 
     return y, transmitted_symbols, channel_noise, random_state
+
+# JP: Leave remainder untouched for next PRs to avoid conflicts before this is merged
 
 def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union[np.array, None] = None,
                       *,

--- a/dimod/generators/mimo.py
+++ b/dimod/generators/mimo.py
@@ -26,29 +26,34 @@ from typing import Callable, Iterable, Optional, Sequence, Tuple, Union
 import dimod 
 
 def _quadratic_form(y, F):
-    """Convert O(v) = ||y - F v||^2 to a sparse quadratic form, where
-    y, F are assumed to be complex or real valued.
-
-    Constructs coefficients for the form O(v) = v^dag J v - 2 Re [h^dag vD] + k
+    """Convert :math:`O(v) = ||y - F v||^2` to sparse quadratic form.
     
-    Inputs
-        v: column vector of complex values
-        y: column vector of complex values
-        F: matrix of complex values
-    Output
-        k: real scalar
-        h: dense real vector
-        J: dense real symmetric matrix
+    Constructs coefficients for the form 
+    :math:`O(v) = v^{\dagger} J v - 2 \Re(h^{\dagger} v) + \\text{offset}`. 
+
+    Args:
+        y: Received symbols as a NumPy column vector of complex or real values.
+
+        F: Wireless channel as an :math:`i \\times j` NumPy matrix of complex 
+            values, where :math:`i` rows correspond to :math:`y_i` receivers 
+            and :math:`j` columns correspond to :math:`v_i` transmitted symbols.
+    
+    Returns:
+        Three tuple of offset, as a real scalar, linear biases :math:`h`, as a dense
+        real vector, and quadratic interactions, :math:`J`, as a dense real symmetric 
+        matrix.
     
     """
     if len(y.shape) != 2 or y.shape[1] != 1:
-        raise ValueError('y should have shape [n, 1] for some n')
+        raise ValueError(f"y should have shape (n, 1) for some n; given: {y.shape}")
+    
     if len(F.shape) != 2 or F.shape[0] != y.shape[0]:
-        raise ValueError('F should have shape [n, m] for some m, n'
-                         'and n should equal y.shape[1]')
+        raise ValueError("F should have shape (n, m) for some m, n "
+                         "and n should equal y.shape[1];" 
+                         f" given: {F.shape}, n={y.shape[1]}")
 
     offset = np.matmul(y.imag.T, y.imag) + np.matmul(y.real.T, y.real)
-    h = - 2*np.matmul(F.T.conj(), y) ## Be careful with interpretation!
+    h = - 2*np.matmul(F.T.conj(), y)    # Be careful with interpretation!
     J = np.matmul(F.T.conj(), F) 
 
     return offset, h, J
@@ -514,6 +519,7 @@ def _create_signal(F, transmitted_symbols=None, channel_noise=None,
     return y, transmitted_symbols, channel_noise, random_state
 
 # JP: Leave remainder untouched for next PRs to avoid conflicts before this is merged
+#     Next PR should bring in commit https://github.com/jackraymond/dimod/commit/ef99d2ae1c364f2066018046a0ece977443b229e
 
 def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union[np.array, None] = None,
                       *,

--- a/dimod/generators/mimo.py
+++ b/dimod/generators/mimo.py
@@ -122,7 +122,7 @@ def _amplitude_modulated_quadratic_form(h, J, modulation):
             num_amps = 2
         elif modulation == '64QAM':
             num_amps = 3
-        else:
+        else:   # JP: add 256QAM
             raise ValueError('unknown modulation')
         
         amps = 2 ** np.arange(num_amps)
@@ -154,7 +154,7 @@ def _symbols_to_spins(symbols: np.array, modulation: str) -> np.array:
             spins_per_real_symbol = 2
         elif modulation == '64QAM':
             spins_per_real_symbol = 3
-        else:
+        else:   # JP: add 256QAM
             raise ValueError('Unsupported modulation')
         # A map from integer parts to real is clearest (and sufficiently performant), 
         # generalizes to Gray coding more easily as well:
@@ -258,45 +258,32 @@ def linear_filter(F, method='zero_forcing', SNRoverNt=float('Inf'), PoverNt=1):
         np.linalg.pinv(np.matmul(F, F.conj().T) + np.identity(Nr)/SNRoverNt)
                     ) / np.sqrt(PoverNt)
 
-def filter_marginal_estimator(x: np.array, modulation: str):
-    if modulation is not None:
-        if modulation == 'BPSK' or modulation == 'QPSK':
-            max_abs = 1
-        elif modulation == '16QAM':
-            max_abs = 3
-        elif modulation == '64QAM':
-            max_abs = 7
-        elif modulation == '128QAM':
-            max_abs = 15
-        else:
-            raise ValueError('Unknown modulation')
-        #Real part (nearest):
-        x_R = 2*np.round((x.real - 1)/2) + 1
-        x_R = np.where(x_R < -max_abs, -max_abs, x_R)
-        x_R = np.where(x_R > max_abs, max_abs, x_R)
-        if modulation != 'BPSK':
-            x_I = 2*np.round((x.imag - 1)/2) + 1
-            x_I = np.where(x_I <- max_abs, -max_abs, x_I)
-            x_I = np.where(x_I > max_abs, max_abs, x_I)
-            return x_R + 1j*x_I
-        else:
-            return x_R
-        
+transmitters_per_spin = {
+    'BPSK': 1,
+    'QPSK': 2,
+    '16QAM': 4,
+    '64QAM': 6} # JP: add 256QAM
+
 def spins_to_symbols(spins: np.array, modulation: str = None, 
                      num_transmitters: int = None) -> np.array:
-    """Converts spins to modulated symbols assuming a linear encoding"""
+    """Convert spins to modulated symbols.
+
+    Args:
+        spins: Spins as a NumPy array. 
+
+        modulation: Modulation. Supported values are non-quadrature modulation 
+            BPSK and quadrature modulations 'QPSK', '16QAM', '64QAM', and '256QAM'.
+
+    Returns:
+        Transmitted symbols as a NumPy vector.
+    """
+    if modulation not in transmitters_per_spin.keys():
+        raise ValueError(f"Unsupported modulation: {modulation}")
+    
     num_spins = len(spins)
+
     if num_transmitters is None:
-        if modulation == 'BPSK':
-            num_transmitters = num_spins
-        elif modulation == 'QPSK':
-            num_transmitters = num_spins//2
-        elif modulation == '16QAM':
-            num_transmitters = num_spins//4
-        elif modulation == '64QAM':
-            num_transmitters = num_spins//6
-        else:
-            raise ValueError('Unsupported modulation')
+        num_transmitters = num_spins // transmitters_per_spin[modulation]
         
     if num_transmitters == num_spins:
         symbols = spins 
@@ -314,7 +301,8 @@ def spins_to_symbols(spins: np.array, modulation: str = None,
         amps = 2**np.arange(0, num_amps)[:, np.newaxis]
         
         symbols = np.sum(amps*spinsR[:, :num_transmitters], axis=0) \
-                + 1j*np.sum(amps*spinsR[:, num_transmitters:], axis=0)
+            + 1j*np.sum(amps*spinsR[:, num_transmitters:], axis=0)
+        
     return symbols
 
 def lattice_to_attenuation_matrix(lattice,transmitters_per_node=1,receivers_per_node=1,neighbor_root_attenuation=1):
@@ -848,3 +836,28 @@ def spin_encoded_comp(lattice: Union[int,nx.Graph],
         bqm.relabel_variables({n: rtn[n] for n in bqm.variables})
     
     return bqm
+
+# Moved to end of file until we do something with this 
+def filter_marginal_estimator(x: np.array, modulation: str):
+    if modulation is not None:
+        if modulation == 'BPSK' or modulation == 'QPSK':
+            max_abs = 1
+        elif modulation == '16QAM':
+            max_abs = 3
+        elif modulation == '64QAM':
+            max_abs = 7
+        elif modulation == '128QAM':
+            max_abs = 15
+        else:
+            raise ValueError('Unknown modulation')
+        #Real part (nearest):
+        x_R = 2*np.round((x.real - 1)/2) + 1
+        x_R = np.where(x_R < -max_abs, -max_abs, x_R)
+        x_R = np.where(x_R > max_abs, max_abs, x_R)
+        if modulation != 'BPSK':
+            x_I = 2*np.round((x.imag - 1)/2) + 1
+            x_I = np.where(x_I <- max_abs, -max_abs, x_I)
+            x_I = np.where(x_I > max_abs, max_abs, x_I)
+            return x_R + 1j*x_I
+        else:
+            return x_R

--- a/dimod/generators/mimo.py
+++ b/dimod/generators/mimo.py
@@ -523,7 +523,7 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
                       F_distribution: Union[None, tuple] = None, 
                       use_offset: bool = False,
                       attenuation_matrix = None) -> dimod.BinaryQuadraticModel:
-    """Generate a multi-input multiple-output (MIMO) channel-decoding problem.
+    """ Generate a multi-input multiple-output (MIMO) channel-decoding problem.
         
     Users each transmit complex valued symbols over a random channel :math:`F` of 
     some num_receivers, subject to additive white Gaussian noise. Given the received
@@ -531,46 +531,42 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
     :math:`MLE = argmin || y - F v ||_2`. When v is encoded as a linear
     sum of spins the optimization problem is defined by a Binary Quadratic Model. 
     Depending on arguments used, this may be a model for Code Division Multiple
-    Access [#T02]_ [#R20]_, 5G communication network problems [#Prince]_, or others.
+    Access _[#T02, #R20], 5G communication network problems _[#Prince], or others.
     
     Args:
         y: A complex or real valued signal in the form of a numpy array. If not
             provided, generated from other arguments.
 
         F: A complex or real valued channel in the form of a numpy array. If not
-            provided, generated from other arguments. Note that for correct interpretation
-            of SNRb, the channel power should be normalized to num_transmitters.
+           provided, generated from other arguments. Note that for correct interpretation
+           of SNRb, the channel power should be normalized to num_transmitters.
 
         modulation: Specifies the constellation (symbol set) in use by 
             each user. Symbols are assumed to be transmitted with equal probability.
             Options are:
+               * 'BPSK'
+                   Binary Phase Shift Keying. Transmitted symbols are +1, -1;
+                   no encoding is required.
+                   A real valued channel is assumed.
 
-            * 'BPSK'
-
-                Binary Phase Shift Keying. Transmitted symbols are +1, -1;
-                no encoding is required. A real valued channel is assumed.
-
-            * 'QPSK'
-
-                Quadrature Phase Shift Keying. 
-                Transmitted symbols are +1, -1, +1j, -1j;
-                spins are encoded as a real vector concatenated with an imaginary vector.
+               * 'QPSK'
+                   Quadrature Phase Shift Keying. 
+                   Transmitted symbols are +1, -1, +1j, -1j;
+                   spins are encoded as a real vector concatenated with an imaginary vector.
                    
-            * '16QAM'
-
-                Each user is assumed to select independently from 16 symbols.
-                The transmitted symbol is a complex value that can be encoded by two spins
-                in the imaginary part, and two spins in the real part. v = 2 s_1 + s_2.
-                Highest precision real and imaginary spin vectors, are concatenated to 
-                lower precision spin vectors.
+               * '16QAM'
+                   Each user is assumed to select independently from 16 symbols.
+                   The transmitted symbol is a complex value that can be encoded by two spins
+                   in the imaginary part, and two spins in the real part. v = 2 s_1 + s_2.
+                   Highest precision real and imaginary spin vectors, are concatenated to 
+                   lower precision spin vectors.
                    
-            * '64QAM'
-
-                A QPSK symbol set is generated, symbols are further amplitude modulated 
-                by an independently and uniformly distributed random amount from [1, 3].
+               * '64QAM'
+                   A QPSK symbol set is generated, symbols are further amplitude modulated 
+                   by an independently and uniformly distributed random amount from [1, 3].
 
         num_transmitters: Number of users. Since each user transmits 1 symbol per frame, also the
-            number of transmitted symbols, must be consistent with F argument.
+             number of transmitted symbols, must be consistent with F argument.
 
         num_receivers: Num_Receivers of channel, :code:`len(y)`. Must be consistent with y argument.
 
@@ -578,7 +574,7 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
             to generate the noisy signal. In the case float('Inf') no noise is 
             added. SNRb = Eb/N0, where Eb is the energy per bit, and N0 is the one-sided
             power-spectral density. A one-sided . N0 is typically kB T at the receiver. 
-            To convert units of dB to SNRb use SNRb=10**(SNRb[decibel]/10).
+            To convert units of dB to SNRb use SNRb=10**(SNRb[decibells]/10).
         
         transmitted_symbols: 
             The set of symbols transmitted, this argument is used in combination with F
@@ -617,12 +613,12 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
            for sparse and structured codes.
     
     Returns:
-        Binary quadratic model defining the log-likelihood function.
+        The binary quadratic model defining the log-likelihood function
 
     Example:
 
         Generate an instance of a CDMA problem in the high-load regime, near a first order
-        phase transition:
+        phase transition _[#T02, #R20]:
 
         >>> num_transmitters = 64
         >>> transmitters_per_receiver = 1.5
@@ -634,12 +630,7 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
 
          
     .. [#T02] T. Tanaka IEEE TRANSACTIONS ON INFORMATION THEORY, VOL. 48, NO. 11, NOVEMBER 2002
-
-    .. [#R20] J. Raymond, N. Ndiaye, G. Rayaprolu and A. D. King, 
-        "Improving performance of logical qubits by parameter tuning and topology compensation," 
-        2020 IEEE International Conference on Quantum Computing and Engineering (QCE), 
-        Denver, CO, USA, 2020, pp. 295-305, doi: 10.1109/QCE49297.2020.00044.
-
+    .. [#R20] J. Raymond, N. Ndiaye, G. Rayaprolu and A. D. King, "Improving performance of logical qubits by parameter tuning and topology compensation, " 2020 IEEE International Conference on Quantum Computing and Engineering (QCE), Denver, CO, USA, 2020, pp. 295-305, doi: 10.1109/QCE49297.2020.00044.
     .. [#Prince] Various (https://paws.princeton.edu/) 
     """
     
@@ -687,9 +678,8 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
         return dimod.BQM(h[:,0], J, 'SPIN')
 
 def _make_honeycomb(L: int):
-    """2L by 2L triangular lattice with open boundaries,
-    and cut corners to make hexagon. 
-    """
+    """ 2L by 2L triangular lattice with open boundaries,
+    and cut corners to make hexagon. """
     G = nx.Graph()
     G.add_edges_from([((x, y), (x,y+ 1)) for x in range(2*L+1) for y in range(2*L)])
     G.add_edges_from([((x, y), (x+1, y)) for x in range(2*L) for y in range(2*L + 1)])
@@ -710,8 +700,7 @@ def spin_encoded_comp(lattice: Union[int,nx.Graph],
                       seed: Union[None, int, np.random.RandomState] = None, 
                       F_distribution: Union[None, str] = None, 
                       use_offset: bool = False) -> dimod.BinaryQuadraticModel:
-    """Generate a simple coooperative multi-point (CoMP) decoding problem.
-
+    """Defines a simple coooperative multi-point decoding problem CoMP.
     Args:
        lattice: A graph defining the set of nearest neighbor basestations. Each 
            basestation has ``num_receivers`` receivers and ``num_transmitters`` 
@@ -732,18 +721,15 @@ def spin_encoded_comp(lattice: Union[int,nx.Graph],
            In specific, for BPSK with at most one transmitter per site, there is 1 
            spin per lattice node with a transmitter, inherits lattice label)
        F: Channel
-
        y: Signal
      
        See for ``spin_encoded_mimo`` for interpretation of other per-basestation parameters. 
-
     Returns:
        bqm: an Ising model in BinaryQuadraticModel format.
     
     Reference: 
         https://en.wikipedia.org/wiki/Cooperative_MIMO
     """
-
     if type(lattice) is not nx.Graph:
         lattice = _make_honeycomb(int(lattice))
     if modulation is None:

--- a/dimod/generators/mimo.py
+++ b/dimod/generators/mimo.py
@@ -523,7 +523,7 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
                       F_distribution: Union[None, tuple] = None, 
                       use_offset: bool = False,
                       attenuation_matrix = None) -> dimod.BinaryQuadraticModel:
-    """ Generate a multi-input multiple-output (MIMO) channel-decoding problem.
+    """Generate a multi-input multiple-output (MIMO) channel-decoding problem.
         
     Users each transmit complex valued symbols over a random channel :math:`F` of 
     some num_receivers, subject to additive white Gaussian noise. Given the received
@@ -531,42 +531,46 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
     :math:`MLE = argmin || y - F v ||_2`. When v is encoded as a linear
     sum of spins the optimization problem is defined by a Binary Quadratic Model. 
     Depending on arguments used, this may be a model for Code Division Multiple
-    Access _[#T02, #R20], 5G communication network problems _[#Prince], or others.
+    Access [#T02]_ [#R20]_, 5G communication network problems [#Prince]_, or others.
     
     Args:
         y: A complex or real valued signal in the form of a numpy array. If not
             provided, generated from other arguments.
 
         F: A complex or real valued channel in the form of a numpy array. If not
-           provided, generated from other arguments. Note that for correct interpretation
-           of SNRb, the channel power should be normalized to num_transmitters.
+            provided, generated from other arguments. Note that for correct interpretation
+            of SNRb, the channel power should be normalized to num_transmitters.
 
         modulation: Specifies the constellation (symbol set) in use by 
             each user. Symbols are assumed to be transmitted with equal probability.
             Options are:
-               * 'BPSK'
-                   Binary Phase Shift Keying. Transmitted symbols are +1, -1;
-                   no encoding is required.
-                   A real valued channel is assumed.
 
-               * 'QPSK'
-                   Quadrature Phase Shift Keying. 
-                   Transmitted symbols are +1, -1, +1j, -1j;
-                   spins are encoded as a real vector concatenated with an imaginary vector.
+            * 'BPSK'
+
+                Binary Phase Shift Keying. Transmitted symbols are +1, -1;
+                no encoding is required. A real valued channel is assumed.
+
+            * 'QPSK'
+
+                Quadrature Phase Shift Keying. 
+                Transmitted symbols are +1, -1, +1j, -1j;
+                spins are encoded as a real vector concatenated with an imaginary vector.
                    
-               * '16QAM'
-                   Each user is assumed to select independently from 16 symbols.
-                   The transmitted symbol is a complex value that can be encoded by two spins
-                   in the imaginary part, and two spins in the real part. v = 2 s_1 + s_2.
-                   Highest precision real and imaginary spin vectors, are concatenated to 
-                   lower precision spin vectors.
+            * '16QAM'
+
+                Each user is assumed to select independently from 16 symbols.
+                The transmitted symbol is a complex value that can be encoded by two spins
+                in the imaginary part, and two spins in the real part. v = 2 s_1 + s_2.
+                Highest precision real and imaginary spin vectors, are concatenated to 
+                lower precision spin vectors.
                    
-               * '64QAM'
-                   A QPSK symbol set is generated, symbols are further amplitude modulated 
-                   by an independently and uniformly distributed random amount from [1, 3].
+            * '64QAM'
+
+                A QPSK symbol set is generated, symbols are further amplitude modulated 
+                by an independently and uniformly distributed random amount from [1, 3].
 
         num_transmitters: Number of users. Since each user transmits 1 symbol per frame, also the
-             number of transmitted symbols, must be consistent with F argument.
+            number of transmitted symbols, must be consistent with F argument.
 
         num_receivers: Num_Receivers of channel, :code:`len(y)`. Must be consistent with y argument.
 
@@ -574,7 +578,7 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
             to generate the noisy signal. In the case float('Inf') no noise is 
             added. SNRb = Eb/N0, where Eb is the energy per bit, and N0 is the one-sided
             power-spectral density. A one-sided . N0 is typically kB T at the receiver. 
-            To convert units of dB to SNRb use SNRb=10**(SNRb[decibells]/10).
+            To convert units of dB to SNRb use SNRb=10**(SNRb[decibel]/10).
         
         transmitted_symbols: 
             The set of symbols transmitted, this argument is used in combination with F
@@ -613,12 +617,12 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
            for sparse and structured codes.
     
     Returns:
-        The binary quadratic model defining the log-likelihood function
+        Binary quadratic model defining the log-likelihood function.
 
     Example:
 
         Generate an instance of a CDMA problem in the high-load regime, near a first order
-        phase transition _[#T02, #R20]:
+        phase transition:
 
         >>> num_transmitters = 64
         >>> transmitters_per_receiver = 1.5
@@ -630,7 +634,12 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
 
          
     .. [#T02] T. Tanaka IEEE TRANSACTIONS ON INFORMATION THEORY, VOL. 48, NO. 11, NOVEMBER 2002
-    .. [#R20] J. Raymond, N. Ndiaye, G. Rayaprolu and A. D. King, "Improving performance of logical qubits by parameter tuning and topology compensation, " 2020 IEEE International Conference on Quantum Computing and Engineering (QCE), Denver, CO, USA, 2020, pp. 295-305, doi: 10.1109/QCE49297.2020.00044.
+
+    .. [#R20] J. Raymond, N. Ndiaye, G. Rayaprolu and A. D. King, 
+        "Improving performance of logical qubits by parameter tuning and topology compensation," 
+        2020 IEEE International Conference on Quantum Computing and Engineering (QCE), 
+        Denver, CO, USA, 2020, pp. 295-305, doi: 10.1109/QCE49297.2020.00044.
+
     .. [#Prince] Various (https://paws.princeton.edu/) 
     """
     
@@ -678,8 +687,9 @@ def spin_encoded_mimo(modulation: str, y: Union[np.array, None] = None, F: Union
         return dimod.BQM(h[:,0], J, 'SPIN')
 
 def _make_honeycomb(L: int):
-    """ 2L by 2L triangular lattice with open boundaries,
-    and cut corners to make hexagon. """
+    """2L by 2L triangular lattice with open boundaries,
+    and cut corners to make hexagon. 
+    """
     G = nx.Graph()
     G.add_edges_from([((x, y), (x,y+ 1)) for x in range(2*L+1) for y in range(2*L)])
     G.add_edges_from([((x, y), (x+1, y)) for x in range(2*L) for y in range(2*L + 1)])
@@ -700,7 +710,8 @@ def spin_encoded_comp(lattice: Union[int,nx.Graph],
                       seed: Union[None, int, np.random.RandomState] = None, 
                       F_distribution: Union[None, str] = None, 
                       use_offset: bool = False) -> dimod.BinaryQuadraticModel:
-    """Defines a simple coooperative multi-point decoding problem CoMP.
+    """Generate a simple coooperative multi-point (CoMP) decoding problem.
+
     Args:
        lattice: A graph defining the set of nearest neighbor basestations. Each 
            basestation has ``num_receivers`` receivers and ``num_transmitters`` 
@@ -721,15 +732,18 @@ def spin_encoded_comp(lattice: Union[int,nx.Graph],
            In specific, for BPSK with at most one transmitter per site, there is 1 
            spin per lattice node with a transmitter, inherits lattice label)
        F: Channel
+
        y: Signal
      
        See for ``spin_encoded_mimo`` for interpretation of other per-basestation parameters. 
+
     Returns:
        bqm: an Ising model in BinaryQuadraticModel format.
     
     Reference: 
         https://en.wikipedia.org/wiki/Cooperative_MIMO
     """
+
     if type(lattice) is not nx.Graph:
         lattice = _make_honeycomb(int(lattice))
     if modulation is None:

--- a/dimod/generators/mimo.py
+++ b/dimod/generators/mimo.py
@@ -25,6 +25,14 @@ from typing import Callable, Iterable, Optional, Sequence, Tuple, Union
 
 import dimod 
 
+mod_config = { # bits per transmitter, amplitudes, transmitters_per_spin, number of amps
+    "BPSK": {"bpt": 1, "amps": 1, "tps": 1, "na": 1},       
+    "QPSK": {"bpt": 2, "amps": 1, "tps": 2, "na": 1},
+    "16QAM": {"bpt": 4, "amps": 2, "tps": 4, "na": 2},
+    "64QAM": {"bpt": 6, "amps": 4, "tps": 6, "na": 3},
+    "256QAM": {"bpt": 8, "amps": 8, "tps": 8, "na": 5}   #JP: check numbers for 256QAM
+    } 
+
 def _quadratic_form(y, F):
     """Convert :math:`O(v) = ||y - F v||^2` to sparse quadratic form.
     
@@ -113,22 +121,13 @@ def _amplitude_modulated_quadratic_form(h, J, modulation):
         vector  and amplitude-modulated quadratic interactions, :math:`J`, as 
         a matrix.
     """
-    if modulation == 'BPSK' or modulation == 'QPSK':
-        #Easy case, just extract diagonal
-        return h, J
-    else:
-        # Quadrature + amplitude modulation
-        if modulation == '16QAM':
-            num_amps = 2
-        elif modulation == '64QAM':
-            num_amps = 3
-        else:   # JP: add 256QAM
-            raise ValueError('unknown modulation')
-        
-        amps = 2 ** np.arange(num_amps)
-        hA = np.kron(amps[:, np.newaxis], h)
-        JA = np.kron(np.kron(amps[:, np.newaxis], amps[np.newaxis, :]), J)
-        return hA, JA 
+    if modulation not in mod_config.keys():
+        raise ValueError(f"Unsupported modulation: {modulation}")
+    
+    amps = 2 ** np.arange(mod_config[modulation]["na"])
+    hA = np.kron(amps[:, np.newaxis], h)
+    JA = np.kron(np.kron(amps[:, np.newaxis], amps[np.newaxis, :]), J)
+    return hA, JA 
       
 def _symbols_to_spins(symbols: np.array, modulation: str) -> np.array:
     """Convert quadrature amplitude modulated (QAM) symbols to spins. 
@@ -258,12 +257,6 @@ def linear_filter(F, method='zero_forcing', SNRoverNt=float('Inf'), PoverNt=1):
         np.linalg.pinv(np.matmul(F, F.conj().T) + np.identity(Nr)/SNRoverNt)
                     ) / np.sqrt(PoverNt)
 
-transmitters_per_spin = {
-    'BPSK': 1,
-    'QPSK': 2,
-    '16QAM': 4,
-    '64QAM': 6} # JP: add 256QAM
-
 def spins_to_symbols(spins: np.array, modulation: str = None, 
                      num_transmitters: int = None) -> np.array:
     """Convert spins to modulated symbols.
@@ -277,13 +270,13 @@ def spins_to_symbols(spins: np.array, modulation: str = None,
     Returns:
         Transmitted symbols as a NumPy vector.
     """
-    if modulation not in transmitters_per_spin.keys():
+    if modulation not in mod_config.keys():
         raise ValueError(f"Unsupported modulation: {modulation}")
     
     num_spins = len(spins)
 
     if num_transmitters is None:
-        num_transmitters = num_spins // transmitters_per_spin[modulation]
+        num_transmitters = num_spins // mod_config[modulation]["tps"]
         
     if num_transmitters == num_spins:
         symbols = spins 
@@ -427,27 +420,19 @@ def create_channel(num_receivers: int = 1, num_transmitters: int = 1,
 
     return F, channel_power, random_state
 
-constellation = {   # bits per transmitter (bpt) and amplitudes (amps)
-    "BPSK": [1, np.ones(1)],       
-    "QPSK": [2, np.ones(1)],
-    "16QAM": [4, 1+2*np.arange(2)],
-    "64QAM": [6, 1+2*np.arange(4)],
-    "256QAM": [8, 1+2*np.arange(8)]} 
-
 def _constellation_properties(modulation):
     """Return bits per symbol, symbol amplitudes, and mean power for QAM constellation. 
     
     Constellation mean power makes the standard assumption that symbols are 
     sampled uniformly at random for the signal.
     """
-
-    bpt_amps = constellation.get(modulation)
-    if not bpt_amps:
+    if modulation not in mod_config.keys():
         raise ValueError('Unsupported modulation method')
-    
-    constellation_mean_power = 1 if modulation == 'BPSK' else 2*np.mean(bpt_amps[1]*bpt_amps[1]) 
 
-    return bpt_amps[0], bpt_amps[1], constellation_mean_power 
+    amps = 1+2*np.arange(mod_config[modulation]["amps"])
+    constellation_mean_power = 1 if modulation == 'BPSK' else 2*np.mean(amps*amps) 
+
+    return mod_config[modulation]["bpt"], amps, constellation_mean_power 
 
 def _create_transmitted_symbols(num_transmitters, 
                                 amps=[-1, 1], 

--- a/docs/reference/generators.rst
+++ b/docs/reference/generators.rst
@@ -49,8 +49,6 @@ Optimization
    random_bin_packing
    random_knapsack
    random_multi_knapsack
-   spin_encoded_comp
-   spin_encoded_mimo
 
 Random
 ======

--- a/docs/reference/generators.rst
+++ b/docs/reference/generators.rst
@@ -51,6 +51,7 @@ Optimization
    random_multi_knapsack
    spin_encoded_comp
    spin_encoded_mimo
+
 Random
 ======
 

--- a/docs/reference/generators.rst
+++ b/docs/reference/generators.rst
@@ -49,6 +49,8 @@ Optimization
    random_bin_packing
    random_knapsack
    random_multi_knapsack
+   spin_encoded_comp
+   spin_encoded_mimo
 
 Random
 ======

--- a/docs/reference/generators.rst
+++ b/docs/reference/generators.rst
@@ -49,7 +49,8 @@ Optimization
    random_bin_packing
    random_knapsack
    random_multi_knapsack
-
+   spin_encoded_comp
+   spin_encoded_mimo
 Random
 ======
 

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1125,7 +1125,10 @@ class TestMIMO(unittest.TestCase):
         h, J = dimod.generators.mimo._real_quadratic_form(h, J)
         val3 = np.matmul(vUnwrap.T, np.matmul(J, vUnwrap)) + np.matmul(h.T, vUnwrap) + k
         self.assertLess(abs(val3), 1e-8)
-        
+
+    def test_real_quadratic_form(self):
+        print('Add tests for _real_quadratic_form')
+
     def test_amplitude_modulated_quadratic_form(self):
         num_var = 3
         h = np.random.random(size=(num_var, 1))
@@ -1143,6 +1146,9 @@ class TestMIMO(unittest.TestCase):
                 self.assertLess(abs(max_val*max_val*np.sum(J)-np.sum(JO)), 1e-8)
                 #self.assertEqual(h.shape[0], num_var*mod_pref[modI])
                 #self.assertLess(abs(bqm.offset-np.sum(np.diag(J))), 1e-8)
+
+    def test_yF_to_hJ(self):
+        print('Add tests for _yF_to_hJ')
 
     def test_symbols_to_spins(self):
         # Standard symbol cases (2D input):

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1059,6 +1059,7 @@ class TestMIMO(unittest.TestCase):
         return effFields
         
     def test_filter_marginal_estimators(self):
+        # Tested but so far this function is unused
         
         filtered_signal = np.random.random(20) + np.arange(-20,20,2)
         estimated_source = dimod.generators.mimo.filter_marginal_estimator(filtered_signal, 'BPSK')
@@ -1149,6 +1150,9 @@ class TestMIMO(unittest.TestCase):
 
     def test_yF_to_hJ(self):
         print('Add tests for _yF_to_hJ')
+
+    def test_spins_to_symbols(self):
+        print('Add tests for spins_to_symbols')
 
     def test_symbols_to_spins(self):
         # Standard symbol cases (2D input):


### PR DESCRIPTION
@jackraymond, this is the first of two general PRs on `mimo.py`. The next one will continue updating internal functions from ``lattice_to_attenuation_matrix`` to ``create_signal`` as needed, add support for 256QAM to all internal functions, and add unittesting for those functions that still don't have it. I'll make separate PRs for updating public functions ``spin_encoded_mimo`` and ``spin_encoded_comp`` in coordination with your King's graph updates. 
Note that currently I'm only adding typing support for public functions (can reconsider later).

Edit: actually I'll still use this PR until you merge to avoid conflicts. At least to expand [this bit](https://github.com/jackraymond/dimod/pull/6/commits/4c2398eadee1de5dcff0403766cdd17b955b01fe) across all functions.